### PR TITLE
fix: Fix max sockets configuration for localtunnel server

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -7,6 +7,7 @@ import log from 'book';
 import Debug from 'debug';
 
 import CreateServer from '../server';
+import {DEFAULT_MAX_SOCKETS} from '../constants';
 
 const debug = Debug('localtunnel');
 
@@ -28,7 +29,7 @@ const argv = optimist
         describe: 'Specify the base domain name. This is optional if hosting localtunnel from a regular example.com domain. This is required if hosting a localtunnel server from a subdomain (i.e. lt.example.dom where clients will be client-app.lt.example.come)',
     })
     .options('max-sockets', {
-        default: 25,
+        default: DEFAULT_MAX_SOCKETS,
         describe: 'maximum number of tcp sockets each client is allowed to establish at one time (the tunnels)'
     })
     .argv;
@@ -39,7 +40,7 @@ if (argv.help) {
 }
 
 const server = CreateServer({
-    max_tcp_sockets: argv['max-sockets'],
+    maxSockets: argv['max-sockets'],
     secure: argv.secure,
     domain: argv.domain,
 });

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,1 @@
+export const DEFAULT_MAX_SOCKETS = 10;

--- a/lib/ClientManager.js
+++ b/lib/ClientManager.js
@@ -37,10 +37,10 @@ class ClientManager {
             id = hri.random();
         }
 
-        const maxSockets = this.opt.max_tcp_sockets;
+        const maxSockets = this.opt.maxSockets;
         const agent = new TunnelAgent({
             clientId: id,
-            maxSockets: 25,
+            maxSockets,
         });
 
         const client = new Client({

--- a/lib/TunnelAgent.js
+++ b/lib/TunnelAgent.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 import log from 'book';
 import Debug from 'debug';
 
-const DEFAULT_MAX_SOCKETS = 10;
+import {DEFAULT_MAX_SOCKETS} from '../constants';
 
 // Implements an http.Agent interface to a pool of tunnel sockets
 // A tunnel socket is a connection _from_ a client that will
@@ -29,7 +29,7 @@ class TunnelAgent extends Agent {
 
         // track maximum allowed sockets
         this.connectedSockets = 0;
-        this.maxTcpSockets = options.maxTcpSockets || DEFAULT_MAX_SOCKETS;
+        this.maxSockets = options.maxSockets || DEFAULT_MAX_SOCKETS;
 
         // new tcp server to service requests for this client
         this.server = net.createServer();
@@ -89,7 +89,7 @@ class TunnelAgent extends Agent {
     // new socket connection from client for tunneling requests to client
     _onConnection(socket) {
         // no more socket connections allowed
-        if (this.connectedSockets >= this.maxTcpSockets) {
+        if (this.connectedSockets >= this.maxSockets) {
             this.debug('no more sockets allowed');
             socket.destroy();
             return false;

--- a/lib/TunnelAgent.test.js
+++ b/lib/TunnelAgent.test.js
@@ -43,7 +43,7 @@ describe('TunnelAgent', () => {
 
     it('should reject connections over the max', async () => {
         const agent = new TunnelAgent({
-            maxTcpSockets: 2,
+            maxSockets: 2,
         });
         assert.equal(agent.started, false);
 


### PR DESCRIPTION
Previously, the max sockets configuration wasn't applied correctly due to the wrong variable name in TunnelAgent.
Additionally, the default configuration for max sockets was defined in two places which led to misconfiguration
in case of changing the default value.

Touches:  cksource/cs#13607